### PR TITLE
Ensure saga compensation operations are executed in LIFO order

### DIFF
--- a/saga/saga.go
+++ b/saga/saga.go
@@ -125,7 +125,8 @@ func compensate(ctx Context, sagaState *sagaState) error {
 			return compensationError
 		}
 	} else {
-		for _, op := range sagaState.compensationOps {
+		for i := len(sagaState.compensationOps) - 1; i >= 0; i-- {
+			op := sagaState.compensationOps[i]
 			err := op(ctx)
 			if err != nil && !sagaState.options.ContinueWithError {
 				return err

--- a/saga/saga_test.go
+++ b/saga/saga_test.go
@@ -40,6 +40,13 @@ func (s *UnitTestSuite) Test_BasicSagaWorkflow_Success() {
 	s.NoError(err)
 	s.Equal(60, currentAmount)
 
+	result, err = env.QueryWorkflow("compensationOrder")
+	s.NoError(err)
+	var compensationOrder []int
+	err = result.Get(&compensationOrder)
+	s.NoError(err)
+	s.Empty(compensationOrder)
+
 	env.AssertExpectations(s.T())
 }
 
@@ -63,6 +70,13 @@ func (s *UnitTestSuite) Test_BasicSagaWorkflow_Failure() {
 	err = result.Get(&currentAmount)
 	s.NoError(err)
 	s.Equal(15, currentAmount)
+
+	result, err = env.QueryWorkflow("compensationOrder")
+	s.NoError(err)
+	var compensationOrder []int
+	err = result.Get(&compensationOrder)
+	s.NoError(err)
+	s.Equal([]int{10, 5}, compensationOrder)
 
 	env.AssertExpectations(s.T())
 }

--- a/saga/workflow_test.go
+++ b/saga/workflow_test.go
@@ -28,18 +28,24 @@ func BasicSagaWorkflow(ctx workflow.Context, initialAmount int) (int, error) {
 	currentAmount := initialAmount
 	var compensationOrder []int
 
-	workflow.SetQueryHandler(ctx, "currentAmount", func(input []byte) (int, error) {
+	err := workflow.SetQueryHandler(ctx, "currentAmount", func(input []byte) (int, error) {
 		return currentAmount, nil
 	})
+	if err != nil {
+		return 0, err
+	}
 
-	workflow.SetQueryHandler(ctx, "compensationOrder", func(input []byte) ([]int, error) {
+	err = workflow.SetQueryHandler(ctx, "compensationOrder", func(input []byte) ([]int, error) {
 		return compensationOrder, nil
 	})
+	if err != nil {
+		return 0, err
+	}
 
-	err := workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 10).Get(ctx, &currentAmount)
+	err = workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 10).Get(ctx, &currentAmount)
 	if err != nil {
 		logger.Error("activity failed", zap.Error(err))
-		Compensate(sagaCtx)
+		handleSagaErr(ctx, Compensate(sagaCtx))
 		return 0, err
 	}
 	AddCompensation(sagaCtx, func(ctx workflow.Context) error {
@@ -55,7 +61,7 @@ func BasicSagaWorkflow(ctx workflow.Context, initialAmount int) (int, error) {
 	err = workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 20).Get(ctx, &currentAmount)
 	if err != nil {
 		logger.Error("activity failed", zap.Error(err))
-		Compensate(sagaCtx)
+		handleSagaErr(ctx, Compensate(sagaCtx))
 		return 0, err
 	}
 	AddCompensation(sagaCtx, func(ctx workflow.Context) error {
@@ -71,7 +77,7 @@ func BasicSagaWorkflow(ctx workflow.Context, initialAmount int) (int, error) {
 	err = workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 30).Get(ctx, &currentAmount)
 	if err != nil {
 		logger.Error("activity failed", zap.Error(err))
-		Compensate(sagaCtx)
+		handleSagaErr(ctx, Compensate(sagaCtx))
 		return 0, err
 	}
 
@@ -96,14 +102,17 @@ func MultipleCompensateSagaWorkflow(ctx workflow.Context, initialAmount int) (in
 
 	currentAmount := initialAmount
 
-	workflow.SetQueryHandler(ctx, "currentAmount", func(input []byte) (int, error) {
+	err := workflow.SetQueryHandler(ctx, "currentAmount", func(input []byte) (int, error) {
 		return currentAmount, nil
 	})
+	if err != nil {
+		return 0, err
+	}
 
-	err := workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 10).Get(ctx, &currentAmount)
+	err = workflow.ExecuteActivity(ctx, ca.Add, currentAmount, 10).Get(ctx, &currentAmount)
 	if err != nil {
 		logger.Error("activity failed", zap.Error(err))
-		Compensate(sagaCtx)
+		handleSagaErr(ctx, Compensate(sagaCtx))
 		return 0, err
 	}
 	AddCompensation(sagaCtx, func(ctx workflow.Context) error {
@@ -115,8 +124,8 @@ func MultipleCompensateSagaWorkflow(ctx workflow.Context, initialAmount int) (in
 		return nil
 	})
 
-	Compensate(sagaCtx)
-	Compensate(sagaCtx)
+	handleSagaErr(ctx, Compensate(sagaCtx))
+	handleSagaErr(ctx, Compensate(sagaCtx))
 
 	return currentAmount, nil
 }
@@ -129,4 +138,11 @@ func (ca *CalculatorActivities) Add(ctx context.Context, a int, b int) (int, err
 
 func (ca *CalculatorActivities) Minus(ctx context.Context, a int, b int) (int, error) {
 	return a - b, nil
+}
+
+func handleSagaErr(ctx workflow.Context, err error) {
+	logger := workflow.GetLogger(ctx)
+	if err != nil {
+		logger.Warn("Error(s) in saga compensation", "error", err)
+	}
 }


### PR DESCRIPTION
It should be reversing actions / going backwards, not FIFO.